### PR TITLE
fix: respect scope parameter in quick setup

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -160,7 +160,7 @@ func quickSetup(sto *storage.Storage, values map[string]string) error {
 		Key:    key,
 		Signup: false,
 		Defaults: settings.UserDefaults{
-			Scope:  ".",
+			Scope:  values["scope"],
 			Locale: "en",
 			Perm: users.Permissions{
 				Admin:    false,


### PR DESCRIPTION
Scope was set to the default regardless of what as provided in config file.
Don't know if we should also overwrite the settings?